### PR TITLE
MTDSA-4037 - controller for retrieve tax calc

### DIFF
--- a/app/v1/controllers/GetIncomeTaxCalcController.scala
+++ b/app/v1/controllers/GetIncomeTaxCalcController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1.controllers
+
+import javax.inject.Inject
+import play.api.mvc.{ Action, AnyContent, ControllerComponents, Request }
+import v1.connectors.httpparsers.StandardHttpParser
+import v1.connectors.httpparsers.StandardHttpParser.SuccessCode
+import v1.controllers.requestParsers.GetCalculationMetadataParser
+import v1.handling.{ RequestDefn, RequestHandling }
+import v1.models.errors._
+import v1.models.request.{ GetCalculationMetadataRawData, GetCalculationMetadataRequest }
+import v1.models.response.CalculationWrapperOrError
+import v1.models.response.getIncomeTaxCalc.GetIncomeTaxCalcResponse
+import v1.services.{ EnrolmentsAuthService, MtdIdLookupService, StandardService }
+
+import scala.concurrent.ExecutionContext
+
+class GetIncomeTaxCalcController @Inject()(
+    authService: EnrolmentsAuthService,
+    lookupService: MtdIdLookupService,
+    parser: GetCalculationMetadataParser,
+    service: StandardService,
+    cc: ControllerComponents
+)(implicit ec: ExecutionContext)
+    extends StandardController[GetCalculationMetadataRawData,
+                               GetCalculationMetadataRequest,
+                               CalculationWrapperOrError[GetIncomeTaxCalcResponse],
+                               GetIncomeTaxCalcResponse,
+                               AnyContent](authService, lookupService, parser, service, cc) { controller =>
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "GetIncomeTaxCalcController", endpointName = "getIncomeTaxCalc")
+
+  override def requestHandlingFor(
+      playRequest: Request[AnyContent],
+      req: GetCalculationMetadataRequest): RequestHandling[CalculationWrapperOrError[GetIncomeTaxCalcResponse], GetIncomeTaxCalcResponse] =
+    RequestHandling[CalculationWrapperOrError[GetIncomeTaxCalcResponse]](RequestDefn.Get(playRequest.path))
+      .withPassThroughErrors(
+        NinoFormatError,
+        CalculationIdFormatError,
+        NotFoundError
+      )
+      .mapSuccess { responseWrapper =>
+        responseWrapper.mapToEither {
+          case CalculationWrapperOrError.ErrorsInCalculation      => Left(MtdErrors(FORBIDDEN, RuleCalculationErrorMessagesExist))
+          case CalculationWrapperOrError.CalculationWrapper(calc) => Right(calc)
+        }
+      }
+
+  override val successCode: StandardHttpParser.SuccessCode = SuccessCode(OK)
+
+  def getIncomeTaxCalc(nino: String, calculationId: String): Action[AnyContent] =
+    authorisedAction(nino).async { implicit request =>
+      val rawData = GetCalculationMetadataRawData(nino, calculationId)
+      doHandleRequest(rawData)
+    }
+}

--- a/app/v1/models/errors/mtdErrors.scala
+++ b/app/v1/models/errors/mtdErrors.scala
@@ -60,6 +60,8 @@ object RuleTaxYearRangeExceededError
 
 object RuleNoIncomeSubmissionsExistError extends MtdError("RULE_NO_INCOME_SUBMISSIONS_EXIST", "No income submissions exist for the tax year")
 
+object RuleCalculationErrorMessagesExist extends MtdError("RULE_CALCULATION_ERROR_MESSAGES_EXIST", "Calculation error messages exist for the supplied calculation ID")
+
 //Standard Errors
 object NotFoundError extends MtdError("MATCHING_RESOURCE_NOT_FOUND", "Matching resource not found")
 

--- a/app/v1/models/outcomes/ResponseWrapper.scala
+++ b/app/v1/models/outcomes/ResponseWrapper.scala
@@ -17,10 +17,16 @@
 package v1.models.outcomes
 
 import cats.implicits._
-import v1.models.errors.{ErrorWrapper, MtdErrors}
+import v1.models.errors.{ ErrorWrapper, MtdErrors }
 
 case class ResponseWrapper[+A](correlationId: String, responseData: A) {
   def map[B](f: A => B): ResponseWrapper[B] = ResponseWrapper(correlationId, f(responseData))
+
+  def mapToEither[B](f: A => Either[MtdErrors, B]): Either[ErrorWrapper, ResponseWrapper[B]] =
+    f(responseData) match {
+      case Right(b)   => ResponseWrapper(correlationId, b).asRight
+      case Left(errs) => ErrorWrapper(Some(correlationId), errs).asLeft
+    }
 
   def toErrorWhen(f: PartialFunction[A, MtdErrors]): Either[ErrorWrapper, ResponseWrapper[A]] =
     f.lift(responseData) match {

--- a/app/v1/models/response/CalculationWrapperOrError.scala
+++ b/app/v1/models/response/CalculationWrapperOrError.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package v1.models.response
 
 import play.api.libs.json.{JsPath, Reads}

--- a/app/v1/models/response/getIncomeTaxCalc/CalculationDetail.scala
+++ b/app/v1/models/response/getIncomeTaxCalc/CalculationDetail.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v1.models.backend.selfAssessment
+package v1.models.response.getIncomeTaxCalc
 
 import play.api.libs.json.{Json, OFormat}
 

--- a/app/v1/models/response/getIncomeTaxCalc/CalculationSummary.scala
+++ b/app/v1/models/response/getIncomeTaxCalc/CalculationSummary.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v1.models.backend.selfAssessment
+package v1.models.response.getIncomeTaxCalc
 
 import play.api.libs.json.{Json, OFormat}
 

--- a/app/v1/models/response/getIncomeTaxCalc/GetIncomeTaxCalcResponse.scala
+++ b/app/v1/models/response/getIncomeTaxCalc/GetIncomeTaxCalcResponse.scala
@@ -14,30 +14,12 @@
  * limitations under the License.
  */
 
-package v1.models.backend.selfAssessment
+package v1.models.response.getIncomeTaxCalc
 
-import play.api.libs.json.{JsSuccess, JsValue, Json}
-import support.UnitSpec
+import play.api.libs.json.{Json, OFormat}
 
-class CalculationDetailSpec extends UnitSpec {
+case class GetIncomeTaxCalcResponse(summary: CalculationSummary, detail: CalculationDetail)
 
-  val json: JsValue = Json.parse(
-    """
-      |{
-      | "incomeTax" : ""
-      |}
-    """.stripMargin)
-
-  val model = CalculationDetail("")
-
-  "CalculationDetail" should {
-
-    "write to json correctly" in {
-      Json.toJson(model) shouldBe json
-    }
-
-    "read from json correctly" in {
-      json.validate[CalculationDetail] shouldBe JsSuccess(model)
-    }
-  }
+object GetIncomeTaxCalcResponse {
+  implicit val format: OFormat[GetIncomeTaxCalcResponse] = Json.format[GetIncomeTaxCalcResponse]
 }

--- a/test/v1/models/response/getIncomeTaxCalc/CalculationDetailSpec.scala
+++ b/test/v1/models/response/getIncomeTaxCalc/CalculationDetailSpec.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package v1.models.backend.selfAssessment
+package v1.models.response.getIncomeTaxCalc
 
 import play.api.libs.json.{JsSuccess, JsValue, Json}
 import support.UnitSpec
 
-class CalculationSummarySpec extends UnitSpec {
+class CalculationDetailSpec extends UnitSpec {
 
   val json: JsValue = Json.parse(
     """
@@ -28,7 +28,7 @@ class CalculationSummarySpec extends UnitSpec {
       |}
     """.stripMargin)
 
-  val model = CalculationSummary("")
+  val model = CalculationDetail("")
 
   "CalculationDetail" should {
 
@@ -37,7 +37,7 @@ class CalculationSummarySpec extends UnitSpec {
     }
 
     "read from json correctly" in {
-      json.validate[CalculationSummary] shouldBe JsSuccess(model)
+      json.validate[CalculationDetail] shouldBe JsSuccess(model)
     }
   }
 }

--- a/test/v1/models/response/getIncomeTaxCalc/CalculationSummarySpec.scala
+++ b/test/v1/models/response/getIncomeTaxCalc/CalculationSummarySpec.scala
@@ -14,12 +14,30 @@
  * limitations under the License.
  */
 
-package v1.models.backend.selfAssessment
+package v1.models.response.getIncomeTaxCalc
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{JsSuccess, JsValue, Json}
+import support.UnitSpec
 
-case class RetrieveIncomeTaxCalcResponse(summary: CalculationSummary, detail: CalculationDetail)
+class CalculationSummarySpec extends UnitSpec {
 
-object RetrieveIncomeTaxCalcResponse {
-  implicit val format: OFormat[RetrieveIncomeTaxCalcResponse] = Json.format[RetrieveIncomeTaxCalcResponse]
+  val json: JsValue = Json.parse(
+    """
+      |{
+      | "incomeTax" : ""
+      |}
+    """.stripMargin)
+
+  val model = CalculationSummary("")
+
+  "CalculationDetail" should {
+
+    "write to json correctly" in {
+      Json.toJson(model) shouldBe json
+    }
+
+    "read from json correctly" in {
+      json.validate[CalculationSummary] shouldBe JsSuccess(model)
+    }
+  }
 }

--- a/test/v1/models/response/getIncomeTaxCalc/GetIncomeTaxCalcResponseSpec.scala
+++ b/test/v1/models/response/getIncomeTaxCalc/GetIncomeTaxCalcResponseSpec.scala
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package v1.models.backend.selfAssessment
+package v1.models.response.getIncomeTaxCalc
 
 import play.api.libs.json.{JsSuccess, JsValue, Json}
 import support.UnitSpec
 
-class RetrieveIncomeTaxCalcResponseSpec extends  UnitSpec {
+class GetIncomeTaxCalcResponseSpec extends  UnitSpec {
 
   val summaryModel = CalculationSummary("")
   val detailModel = CalculationDetail("")
-  val model = RetrieveIncomeTaxCalcResponse(summaryModel, detailModel)
+  val model = GetIncomeTaxCalcResponse(summaryModel, detailModel)
 
   val json: JsValue = Json.parse(
     s"""
@@ -40,7 +40,7 @@ class RetrieveIncomeTaxCalcResponseSpec extends  UnitSpec {
     }
 
     "read from json correctly" in {
-      json.validate[RetrieveIncomeTaxCalcResponse] shouldBe JsSuccess(model)
+      json.validate[GetIncomeTaxCalcResponse] shouldBe JsSuccess(model)
     }
   }
 


### PR DESCRIPTION
Work in progress:
- No tests as yet. 
- Just controller to check that can in principle map to the RULE_CALCULATION_ERROR_MESSAGES_EXIST error when error count > 0 

- NOTE: Reads for GetIncomeTaxCalcResponse will need fixing up so that (as with CalculationMetadata) it locates the calculation as a single object at a particular path in the back end response.