### PR TITLE
MTDSA-13299: TYS Updates For Hateoas Links

### DIFF
--- a/app/v3/controllers/ListCalculationsController.scala
+++ b/app/v3/controllers/ListCalculationsController.scala
@@ -63,7 +63,7 @@ class ListCalculationsController @Inject() (val authService: EnrolmentsAuthServi
           parsedRequest   <- EitherT.fromEither[Future](parser.parseRequest(rawData))
           serviceResponse <- EitherT(service.list(parsedRequest))
         } yield {
-          val vendorResponse = hateoasFactory.wrapList(serviceResponse.responseData, ListCalculationsHateoasData(nino, taxYear))
+          val vendorResponse = hateoasFactory.wrapList(serviceResponse.responseData, ListCalculationsHateoasData(nino, parsedRequest.taxYear))
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +
               s"Success response received with CorrelationId: ${serviceResponse.correlationId}")

--- a/app/v3/controllers/RetrieveCalculationController.scala
+++ b/app/v3/controllers/RetrieveCalculationController.scala
@@ -61,15 +61,16 @@ class RetrieveCalculationController @Inject() (val authService: EnrolmentsAuthSe
         for {
           parsedRequest <- EitherT.fromEither[Future](retrieveCalculationParser.parseRequest(rawData))
           response      <- EitherT(service.retrieveCalculation(parsedRequest))
-          hateoasResponse <- EitherT.fromEither[Future](
-            hateoasFactory
-              .wrap(
-                response.responseData,
-                RetrieveCalculationHateoasData(nino = nino, taxYear = taxYear, calculationId = calculationId, response = response.responseData)
-              )
-              .asRight[ErrorWrapper]
-          )
         } yield {
+          val hateoasData = RetrieveCalculationHateoasData(
+            nino = nino,
+            taxYear = parsedRequest.taxYear,
+            calculationId = calculationId,
+            response = response.responseData
+          )
+
+          val hateoasResponse = hateoasFactory.wrap(response.responseData, hateoasData)
+
           logger.info(
             s"[${endpointLogContext.controllerName}][${endpointLogContext.endpointName}] - " +
               s"Success response received with correlationId: ${response.correlationId}"

--- a/app/v3/controllers/TriggerCalculationController.scala
+++ b/app/v3/controllers/TriggerCalculationController.scala
@@ -63,7 +63,13 @@ class TriggerCalculationController @Inject() (val authService: EnrolmentsAuthSer
           parsedRequest   <- wrap(parser.parseRequest(rawData))
           serviceResponse <- wrap(service.triggerCalculation(parsedRequest))
         } yield {
-          val hateoasData = TriggerCalculationHateoasData(nino, taxYear, parsedRequest.finalDeclaration, serviceResponse.responseData.calculationId)
+          val hateoasData = TriggerCalculationHateoasData(
+            nino = nino,
+            taxYear = parsedRequest.taxYear,
+            finalDeclaration = parsedRequest.finalDeclaration,
+            calculationId = serviceResponse.responseData.calculationId
+          )
+
           val vendorResponse = hateoasFactory.wrap(serviceResponse.responseData, hateoasData)
 
           logger.info(

--- a/app/v3/controllers/requestParsers/ListCalculationsParser.scala
+++ b/app/v3/controllers/requestParsers/ListCalculationsParser.scala
@@ -28,7 +28,7 @@ class ListCalculationsParser @Inject() (val validator: ListCalculationsValidator
 
   override protected def requestFor(data: ListCalculationsRawData): ListCalculationsRequest = ListCalculationsRequest(
     Nino(data.nino),
-    data.taxYear.fold(Option.empty[TaxYear])(taxYear => Some(TaxYear.fromMtd(taxYear)))
+    data.taxYear.map(TaxYear.fromMtd)
   )
 
 }

--- a/app/v3/hateoas/HateoasLinks.scala
+++ b/app/v3/hateoas/HateoasLinks.scala
@@ -39,13 +39,11 @@ trait HateoasLinks {
 
   // API resource links
 
-  def trigger(appConfig: AppConfig, nino: String, taxYear: TaxYear): Link = {
-    Link(
-      href = baseSaUriWithTaxYear(appConfig, nino, taxYear),
-      method = POST,
-      rel = TRIGGER
-    )
-  }
+  def trigger(appConfig: AppConfig, nino: String, taxYear: TaxYear): Link = Link(
+    href = baseSaUriWithTaxYear(appConfig, nino, taxYear),
+    method = POST,
+    rel = TRIGGER
+  )
 
   def list(appConfig: AppConfig, nino: String, taxYear: Option[TaxYear], isSelf: Boolean): Link = {
     val href = withTaxYearParameter(baseSaUri(appConfig, nino), taxYear)

--- a/app/v3/hateoas/HateoasLinks.scala
+++ b/app/v3/hateoas/HateoasLinks.scala
@@ -17,25 +17,37 @@
 package v3.hateoas
 
 import config.AppConfig
+import v3.models.domain.TaxYear
 import v3.models.hateoas.Link
 import v3.models.hateoas.Method._
 import v3.models.hateoas.RelType._
 
 trait HateoasLinks {
+//
+//  private def withTaxYearParameter(appConfig: AppConfig, uri: String, maybeTaxYear: Option[TaxYear]): String = {
+//    implicit val featureSwitches: FeatureSwitches = FeatureSwitches(appConfig.featureSwitches)
+//
+//    maybeTaxYear match {
+//      case Some(taxYear) if taxYear.useTaxYearSpecificApi => s"$uri?taxYear=${taxYear.asMtd}"
+//      case _ => uri
+//    }
+//  }
 
   private def baseSaUri(appConfig: AppConfig, nino: String): String =
     s"/${appConfig.apiGatewayContext}/$nino/self-assessment"
 
-  private def baseSaUriWithTaxYear(appConfig: AppConfig, nino: String, taxYear: String): String =
-    s"/${appConfig.apiGatewayContext}/$nino/self-assessment/$taxYear"
+  private def baseSaUriWithTaxYear(appConfig: AppConfig, nino: String, taxYear: TaxYear): String =
+    s"/${appConfig.apiGatewayContext}/$nino/self-assessment/${taxYear.asMtd}"
 
   // API resource links
 
-  def trigger(appConfig: AppConfig, nino: String, taxYear: String): Link = Link(
-    href = baseSaUriWithTaxYear(appConfig, nino, taxYear),
-    method = POST,
-    rel = TRIGGER
-  )
+  def trigger(appConfig: AppConfig, nino: String, taxYear: TaxYear): Link = {
+    Link(
+      href = baseSaUriWithTaxYear(appConfig, nino, taxYear),
+      method = POST,
+      rel = TRIGGER
+    )
+  }
 
   def list(appConfig: AppConfig, nino: String, isSelf: Boolean): Link = Link(
     href = baseSaUri(appConfig, nino),
@@ -43,14 +55,14 @@ trait HateoasLinks {
     rel = if (isSelf) SELF else LIST
   )
 
-  def retrieve(appConfig: AppConfig, nino: String, taxYear: String, calculationId: String): Link = Link(
+  def retrieve(appConfig: AppConfig, nino: String, taxYear: TaxYear, calculationId: String): Link = Link(
     href = baseSaUriWithTaxYear(appConfig, nino, taxYear) + s"/$calculationId",
     method = GET,
     rel = SELF
   )
 
-  def submitFinalDeclaration(appConfig: AppConfig, nino: String, taxYear: String, calculationId: String): Link = Link(
-    href = s"${baseSaUri(appConfig, nino)}/$taxYear/$calculationId/final-declaration",
+  def submitFinalDeclaration(appConfig: AppConfig, nino: String, taxYear: TaxYear, calculationId: String): Link = Link(
+    href = s"${baseSaUriWithTaxYear(appConfig, nino, taxYear)}/$calculationId/final-declaration",
     method = POST,
     rel = SUBMIT_FINAL_DECLARATION
   )

--- a/app/v3/hateoas/HateoasLinks.scala
+++ b/app/v3/hateoas/HateoasLinks.scala
@@ -23,15 +23,13 @@ import v3.models.hateoas.Method._
 import v3.models.hateoas.RelType._
 
 trait HateoasLinks {
-//
-//  private def withTaxYearParameter(appConfig: AppConfig, uri: String, maybeTaxYear: Option[TaxYear]): String = {
-//    implicit val featureSwitches: FeatureSwitches = FeatureSwitches(appConfig.featureSwitches)
-//
-//    maybeTaxYear match {
-//      case Some(taxYear) if taxYear.useTaxYearSpecificApi => s"$uri?taxYear=${taxYear.asMtd}"
-//      case _ => uri
-//    }
-//  }
+
+  private def withTaxYearParameter(uri: String, maybeTaxYear: Option[TaxYear]): String = {
+    maybeTaxYear match {
+      case Some(taxYear) => s"$uri?taxYear=${taxYear.asMtd}"
+      case _             => uri
+    }
+  }
 
   private def baseSaUri(appConfig: AppConfig, nino: String): String =
     s"/${appConfig.apiGatewayContext}/$nino/self-assessment"
@@ -49,11 +47,11 @@ trait HateoasLinks {
     )
   }
 
-  def list(appConfig: AppConfig, nino: String, isSelf: Boolean): Link = Link(
-    href = baseSaUri(appConfig, nino),
-    method = GET,
-    rel = if (isSelf) SELF else LIST
-  )
+  def list(appConfig: AppConfig, nino: String, taxYear: Option[TaxYear], isSelf: Boolean): Link = {
+    val href = withTaxYearParameter(baseSaUri(appConfig, nino), taxYear)
+
+    Link(href = href, method = GET, rel = if (isSelf) SELF else LIST)
+  }
 
   def retrieve(appConfig: AppConfig, nino: String, taxYear: TaxYear, calculationId: String): Link = Link(
     href = baseSaUriWithTaxYear(appConfig, nino, taxYear) + s"/$calculationId",

--- a/app/v3/models/response/listCalculations/ListCalculationsResponse.scala
+++ b/app/v3/models/response/listCalculations/ListCalculationsResponse.scala
@@ -20,6 +20,7 @@ import cats.Functor
 import config.AppConfig
 import play.api.libs.json._
 import v3.hateoas.{HateoasLinks, HateoasListLinksFactory}
+import v3.models.domain.TaxYear
 import v3.models.hateoas
 import v3.models.hateoas.HateoasData
 
@@ -34,15 +35,15 @@ object ListCalculationsResponse extends HateoasLinks {
   implicit object ListLinksFactory extends HateoasListLinksFactory[ListCalculationsResponse, Calculation, ListCalculationsHateoasData] {
 
     override def itemLinks(appConfig: AppConfig, data: ListCalculationsHateoasData, item: Calculation): Seq[hateoas.Link] = Seq(
-      retrieve(appConfig, data.nino, data.taxYear.getOrElse("????-??"), item.calculationId) // There is a standing question about the tax year here.
+      retrieve(appConfig, data.nino, item.taxYear.get, item.calculationId)
     )
 
     override def links(appConfig: AppConfig, data: ListCalculationsHateoasData): Seq[hateoas.Link] = {
       import data._
       Seq(
-        trigger(appConfig, nino, taxYear.getOrElse("????-??")), // There is a standing question about the tax year here.
-        list(appConfig, nino, isSelf = true)
-      )
+        data.taxYear.map(trigger(appConfig, nino, _)),
+        Some(list(appConfig, nino, isSelf = true))
+      ).flatten
     }
 
   }
@@ -56,4 +57,4 @@ object ListCalculationsResponse extends HateoasLinks {
 
 }
 
-case class ListCalculationsHateoasData(nino: String, taxYear: Option[String]) extends HateoasData
+case class ListCalculationsHateoasData(nino: String, taxYear: Option[TaxYear]) extends HateoasData

--- a/app/v3/models/response/listCalculations/ListCalculationsResponse.scala
+++ b/app/v3/models/response/listCalculations/ListCalculationsResponse.scala
@@ -42,7 +42,7 @@ object ListCalculationsResponse extends HateoasLinks {
       import data._
       Seq(
         data.taxYear.map(trigger(appConfig, nino, _)),
-        Some(list(appConfig, nino, isSelf = true))
+        Some(list(appConfig, nino, taxYear, isSelf = true))
       ).flatten
     }
 

--- a/app/v3/models/response/listCalculations/ListCalculationsResponse.scala
+++ b/app/v3/models/response/listCalculations/ListCalculationsResponse.scala
@@ -34,9 +34,8 @@ object ListCalculationsResponse extends HateoasLinks {
 
   implicit object ListLinksFactory extends HateoasListLinksFactory[ListCalculationsResponse, Calculation, ListCalculationsHateoasData] {
 
-    override def itemLinks(appConfig: AppConfig, data: ListCalculationsHateoasData, item: Calculation): Seq[hateoas.Link] = Seq(
-      retrieve(appConfig, data.nino, item.taxYear.get, item.calculationId)
-    )
+    override def itemLinks(appConfig: AppConfig, data: ListCalculationsHateoasData, item: Calculation): Seq[hateoas.Link] =
+      Seq(item.taxYear.map(retrieve(appConfig, data.nino, _, item.calculationId))).flatten
 
     override def links(appConfig: AppConfig, data: ListCalculationsHateoasData): Seq[hateoas.Link] = {
       import data._

--- a/app/v3/models/response/retrieveCalculation/RetrieveCalculationResponse.scala
+++ b/app/v3/models/response/retrieveCalculation/RetrieveCalculationResponse.scala
@@ -19,6 +19,7 @@ package v3.models.response.retrieveCalculation
 import config.AppConfig
 import play.api.libs.json.{Json, OWrites, Reads}
 import v3.hateoas.{HateoasLinks, HateoasLinksFactory}
+import v3.models.domain.TaxYear
 import v3.models.hateoas.{HateoasData, Link}
 import v3.models.response.retrieveCalculation.calculation.Calculation
 import v3.models.response.retrieveCalculation.inputs.Inputs
@@ -74,7 +75,7 @@ object RetrieveCalculationResponse extends HateoasLinks {
 
 case class RetrieveCalculationHateoasData(
     nino: String,
-    taxYear: String,
+    taxYear: TaxYear,
     calculationId: String,
     response: RetrieveCalculationResponse
 ) extends HateoasData

--- a/app/v3/models/response/triggerCalculation/TriggerCalculationResponse.scala
+++ b/app/v3/models/response/triggerCalculation/TriggerCalculationResponse.scala
@@ -19,6 +19,7 @@ package v3.models.response.triggerCalculation
 import config.AppConfig
 import play.api.libs.json._
 import v3.hateoas.{HateoasLinks, HateoasLinksFactory}
+import v3.models.domain.TaxYear
 import v3.models.hateoas.{HateoasData, Link}
 
 case class TriggerCalculationResponse(calculationId: String)
@@ -40,4 +41,4 @@ object TriggerCalculationResponse extends HateoasLinks {
 
 }
 
-case class TriggerCalculationHateoasData(nino: String, taxYear: String, finalDeclaration: Boolean, calculationId: String) extends HateoasData
+case class TriggerCalculationHateoasData(nino: String, taxYear: TaxYear, finalDeclaration: Boolean, calculationId: String) extends HateoasData

--- a/app/v3/models/response/triggerCalculation/TriggerCalculationResponse.scala
+++ b/app/v3/models/response/triggerCalculation/TriggerCalculationResponse.scala
@@ -33,7 +33,7 @@ object TriggerCalculationResponse extends HateoasLinks {
 
     override def links(appConfig: AppConfig, data: TriggerCalculationHateoasData): Seq[Link] =
       Seq(
-        list(appConfig, data.nino, isSelf = false),
+        list(appConfig, data.nino, Some(data.taxYear), isSelf = false),
         retrieve(appConfig, data.nino, data.taxYear, data.calculationId)
       )
 

--- a/it/v3/endpoints/ListCalculationsControllerISpec.scala
+++ b/it/v3/endpoints/ListCalculationsControllerISpec.scala
@@ -95,7 +95,7 @@ class ListCalculationsControllerISpec extends V3IntegrationBaseSpec with ListCal
         val response: WSResponse = await(request.get)
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe listCalculationsMtdJsonWithHateoas(nino, taxYear.getOrElse("????-??"))
+        response.json shouldBe listCalculationsMtdJsonWithHateoas(nino, taxYear.get)
       }
 
       "valid request is made without a tax year" in new NonTysTest {
@@ -111,10 +111,10 @@ class ListCalculationsControllerISpec extends V3IntegrationBaseSpec with ListCal
         val response: WSResponse = await(request.get)
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe listCalculationsMtdJsonWithHateoas(nino, taxYear.getOrElse("????-??"))
+        response.json shouldBe listCalculationsMtdJsonWithHateoasNoTaxYear(nino)
       }
 
-      "valid TYS request is made without a tax year" in new TysIfsTest {
+      "valid TYS request is made with a tax year" in new TysIfsTest {
         override def setupStubs(): StubMapping = {
           AuditStub.audit()
           AuthStub.authorised()
@@ -125,7 +125,7 @@ class ListCalculationsControllerISpec extends V3IntegrationBaseSpec with ListCal
         val response: WSResponse = await(request.get)
         response.status shouldBe OK
         response.header("Content-Type") shouldBe Some("application/json")
-        response.json shouldBe listCalculationsMtdJsonWithHateoas(nino, taxYear.getOrElse("????-??"))
+        response.json shouldBe listCalculationsMtdJsonWithHateoas(nino, taxYear.get)
       }
     }
 

--- a/it/v3/endpoints/TriggerCalculationControllerISpec.scala
+++ b/it/v3/endpoints/TriggerCalculationControllerISpec.scala
@@ -200,12 +200,12 @@ class TriggerCalculationControllerISpec extends V3IntegrationBaseSpec {
         | "calculationId" : "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
         | "links":[
         |   {
-        |     "href":"/individuals/calculations/AA123456A/self-assessment",
+        |     "href":"/individuals/calculations/AA123456A/self-assessment?taxYear=$mtdTaxYear",
         |     "method":"GET",
         |     "rel":"list"
         |   },
         |   {
-        |     "href":"/individuals/calculations/AA123456A/self-assessment/${mtdTaxYear}/f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
+        |     "href":"/individuals/calculations/AA123456A/self-assessment/$mtdTaxYear/f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c",
         |     "method":"GET",
         |     "rel":"self"
         |   }

--- a/test/v3/controllers/ListCalculationsControllerSpec.scala
+++ b/test/v3/controllers/ListCalculationsControllerSpec.scala
@@ -36,7 +36,7 @@ import scala.concurrent.Future
 
 class ListCalculationsControllerSpec extends ControllerBaseSpec with ListCalculationsFixture {
   val defaultNino: String                     = "AA111111A"
-  val defaultTaxYear: Option[String]          = Some("2018-19")
+  val defaultTaxYear: Option[String]          = Some("2020-21")
   val defaultRawData: ListCalculationsRawData = ListCalculationsRawData(defaultNino, defaultTaxYear)
 
   case class Test(rawData: ListCalculationsRawData = defaultRawData)
@@ -103,7 +103,7 @@ class ListCalculationsControllerSpec extends ControllerBaseSpec with ListCalcula
                   method = Method.POST
                 ),
                 Link(
-                  href = s"/individuals/calculations/$nino/self-assessment",
+                  href = s"/individuals/calculations/$nino/self-assessment?taxYear=${taxYear.get}",
                   rel = RelType.SELF,
                   method = Method.GET
                 )

--- a/test/v3/controllers/ListCalculationsControllerSpec.scala
+++ b/test/v3/controllers/ListCalculationsControllerSpec.scala
@@ -55,7 +55,7 @@ class ListCalculationsControllerSpec extends ControllerBaseSpec with ListCalcula
 
     lazy val request: ListCalculationsRequest = ListCalculationsRequest(
       nino = Nino(nino),
-      taxYear = taxYear.fold(Option.empty[TaxYear])(taxYear => Some(TaxYear.fromMtd(taxYear)))
+      taxYear = taxYear.map(TaxYear.fromMtd)
     )
 
     val controller: ListCalculationsController = new ListCalculationsController(
@@ -85,7 +85,7 @@ class ListCalculationsControllerSpec extends ControllerBaseSpec with ListCalcula
           )
 
         MockHateoasFactory
-          .wrapList(listCalculationsResponseModel, ListCalculationsHateoasData(nino, taxYear))
+          .wrapList(listCalculationsResponseModel, ListCalculationsHateoasData(nino, taxYear.map(TaxYear.fromMtd)))
           .returns(
             HateoasWrapper(
               ListCalculationsResponse(Seq(HateoasWrapper(

--- a/test/v3/controllers/RetrieveCalculationControllerSpec.scala
+++ b/test/v3/controllers/RetrieveCalculationControllerSpec.scala
@@ -188,7 +188,7 @@ class RetrieveCalculationControllerSpec
           .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
 
         MockHateoasFactory
-          .wrap(response, RetrieveCalculationHateoasData(nino, taxYear, calculationId, response))
+          .wrap(response, RetrieveCalculationHateoasData(nino, TaxYear.fromMtd(taxYear), calculationId, response))
           .returns(HateoasWrapper(response, Seq(testHateoasLink)))
 
         val result: Future[Result] = controller.retrieveCalculation(nino, taxYear, calculationId)(fakeGetRequest)

--- a/test/v3/controllers/TriggerCalculationControllerSpec.scala
+++ b/test/v3/controllers/TriggerCalculationControllerSpec.scala
@@ -131,7 +131,7 @@ class TriggerCalculationControllerSpec
           .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
 
         MockHateoasFactory
-          .wrap(response, TriggerCalculationHateoasData(nino, rawTaxYear, finalDeclaration = requestData.finalDeclaration, calculationId))
+          .wrap(response, TriggerCalculationHateoasData(nino, TaxYear.fromMtd(rawTaxYear), finalDeclaration = requestData.finalDeclaration, calculationId))
           .returns(HateoasWrapper(response, Seq(testHateoasLink)))
 
         val result: Future[Result] =

--- a/test/v3/fixtures/ListCalculationsFixture.scala
+++ b/test/v3/fixtures/ListCalculationsFixture.scala
@@ -74,7 +74,7 @@ trait ListCalculationsFixture {
     |         "finalDeclarationTimestamp":"2021-07-13T07:51:43.112Z",
     |         "links":[
     |            {
-    |               "href":"/individuals/calculations/$nino/self-assessment/$taxYear/c432a56d-e811-474c-a26a-76fc3bcaefe5",
+    |               "href":"/individuals/calculations/$nino/self-assessment/2020-21/c432a56d-e811-474c-a26a-76fc3bcaefe5",
     |               "rel":"self",
     |               "method":"GET"
     |            }
@@ -88,12 +88,44 @@ trait ListCalculationsFixture {
     |         "method":"POST"
     |      },
     |      {
-    |         "href":"/individuals/calculations/$nino/self-assessment",
+    |         "href":"/individuals/calculations/$nino/self-assessment?taxYear=$taxYear",
     |         "rel":"self",
     |         "method":"GET"
     |      }
     |   ]
     |}
+  """.stripMargin)
+
+  def listCalculationsMtdJsonWithHateoasNoTaxYear(nino: String): JsValue = Json.parse(s"""
+       |{
+       |   "calculations":[
+       |      {
+       |         "calculationId":"c432a56d-e811-474c-a26a-76fc3bcaefe5",
+       |         "calculationTimestamp":"2021-07-12T07:51:43.112Z",
+       |         "calculationType":"finalDeclaration",
+       |         "requestedBy":"customer",
+       |         "taxYear":"2020-21",
+       |         "totalIncomeTaxAndNicsDue":10000.12,
+       |         "intentToSubmitFinalDeclaration":true,
+       |         "finalDeclaration":true,
+       |         "finalDeclarationTimestamp":"2021-07-13T07:51:43.112Z",
+       |         "links":[
+       |            {
+       |               "href":"/individuals/calculations/$nino/self-assessment/2020-21/c432a56d-e811-474c-a26a-76fc3bcaefe5",
+       |               "rel":"self",
+       |               "method":"GET"
+       |            }
+       |         ]
+       |      }
+       |   ],
+       |   "links":[
+       |      {
+       |         "href":"/individuals/calculations/$nino/self-assessment",
+       |         "rel":"self",
+       |         "method":"GET"
+       |      }
+       |   ]
+       |}
   """.stripMargin)
 
   val calculationModel: Calculation = Calculation(

--- a/test/v3/hateoas/HateoasLinksSpec.scala
+++ b/test/v3/hateoas/HateoasLinksSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v3.hateoas
+
+import mocks.MockAppConfig
+import play.api.Configuration
+import support.UnitSpec
+import v3.models.domain.TaxYear
+import v3.models.hateoas.{Link, Method}
+
+class HateoasLinksSpec extends UnitSpec with MockAppConfig {
+
+//  private val nino        = "AA111111A"
+  private val taxYear2023 = TaxYear.fromMtd("2022-23")
+  private val taxYear2024 = TaxYear.fromMtd("2023-24")
+
+  object Target extends HateoasLinks
+
+  class Test {
+    MockAppConfig.apiGatewayContext.returns("context").anyNumberOfTimes
+  }
+
+  class TysDisabledTest extends Test {
+    MockAppConfig.featureSwitches returns Configuration("tys-api.enabled" -> false)
+  }
+
+  class TysEnabledTest extends Test {
+    MockAppConfig.featureSwitches returns Configuration("tys-api.enabled" -> true)
+  }
+
+  "HateoasLinks" when {
+    "trigger" should {
+//      assertCorrectLink(makeLink)
+    }
+  }
+
+  def assertCorrectLink(makeLink: Option[TaxYear] => Link, baseHref: String, method: Method, rel: String): Unit = {
+    "return the correct link" in new TysDisabledTest {
+      makeLink(None) shouldBe Link(href = baseHref, method = method, rel = rel)
+    }
+
+    "TYS feature switch is disabled" should {
+      "not include tax year query parameter given a TYS tax year" in new TysDisabledTest {
+        makeLink(Some(taxYear2024)) shouldBe Link(href = baseHref, method = method, rel = rel)
+      }
+    }
+
+    "TYS feature switch is enabled" should {
+      "not include tax year query parameter given a non-TYS tax year" in new TysEnabledTest {
+        makeLink(Some(taxYear2023)) shouldBe Link(href = baseHref, method = method, rel = rel)
+      }
+
+      "include tax year query parameter given a TYS tax year" in new TysEnabledTest {
+        makeLink(Some(taxYear2024)) shouldBe Link(href = s"$baseHref?taxYear=2023-24", method = method, rel = rel)
+      }
+    }
+  }
+
+}

--- a/test/v3/models/response/listCalculations/ListCalculationsResponseSpec.scala
+++ b/test/v3/models/response/listCalculations/ListCalculationsResponseSpec.scala
@@ -102,38 +102,27 @@ class ListCalculationsResponseSpec extends UnitSpec with ListCalculationsFixture
         )
     }
 
-    // TODO: Implement me
-//    "do ??? when calculation does not contain tax year" in new Test {
-//      val calculationWithoutTaxYear = calculationModel.copy(taxYear = None)
-//      val responseWithoutTaxYear    = ListCalculationsResponse(Seq(calculationWithoutTaxYear))
-//
-//      hateoasFactory.wrapList(responseWithoutTaxYear, ListCalculationsHateoasData(nino, Some(taxYear))) shouldBe
-//        HateoasWrapper(
-//          payload = ListCalculationsResponse(
-//            Seq(
-//              HateoasWrapper(
-//                calculationModel,
-//                Seq(
-//                  Link(
-//                    href = s"/individuals/calculations/someNino/self-assessment/2020-21/$calcId",
-//                    rel = RelType.SELF,
-//                    method = Method.GET
-//                  )
-//                )))),
-//          links = Seq(
-//            Link(
-//              href = s"/individuals/calculations/someNino/self-assessment/2020-21",
-//              rel = RelType.TRIGGER,
-//              method = Method.POST
-//            ),
-//            Link(
-//              href = "/individuals/calculations/someNino/self-assessment",
-//              rel = RelType.SELF,
-//              method = Method.GET
-//            )
-//          )
-//        )
-//    }
+    "omit retrieve item link when calculation does not contain tax year" in new Test {
+      val calculationWithoutTaxYear = calculationModel.copy(taxYear = None)
+      val responseWithoutTaxYear    = ListCalculationsResponse(Seq(calculationWithoutTaxYear))
+
+      hateoasFactory.wrapList(responseWithoutTaxYear, ListCalculationsHateoasData(nino, Some(taxYear))) shouldBe
+        HateoasWrapper(
+          payload = ListCalculationsResponse(Seq(HateoasWrapper(calculationWithoutTaxYear, Seq()))),
+          links = Seq(
+            Link(
+              href = s"/individuals/calculations/someNino/self-assessment/2020-21",
+              rel = RelType.TRIGGER,
+              method = Method.POST
+            ),
+            Link(
+              href = "/individuals/calculations/someNino/self-assessment?taxYear=2020-21",
+              rel = RelType.SELF,
+              method = Method.GET
+            )
+          )
+        )
+    }
   }
 
 }

--- a/test/v3/models/response/listCalculations/ListCalculationsResponseSpec.scala
+++ b/test/v3/models/response/listCalculations/ListCalculationsResponseSpec.scala
@@ -70,7 +70,7 @@ class ListCalculationsResponseSpec extends UnitSpec with ListCalculationsFixture
               method = Method.POST
             ),
             Link(
-              href = "/individuals/calculations/someNino/self-assessment",
+              href = "/individuals/calculations/someNino/self-assessment?taxYear=2020-21",
               rel = RelType.SELF,
               method = Method.GET
             )

--- a/test/v3/models/response/listCalculations/ListCalculationsResponseSpec.scala
+++ b/test/v3/models/response/listCalculations/ListCalculationsResponseSpec.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.Json
 import support.UnitSpec
 import v3.fixtures.ListCalculationsFixture
 import v3.hateoas.HateoasFactory
+import v3.models.domain.TaxYear
 import v3.models.hateoas.{HateoasWrapper, Link, Method, RelType}
 
 class ListCalculationsResponseSpec extends UnitSpec with ListCalculationsFixture {
@@ -41,14 +42,15 @@ class ListCalculationsResponseSpec extends UnitSpec with ListCalculationsFixture
 
   "HateoasFactory" must {
     trait Test extends MockAppConfig {
-      val hateoasFactory          = new HateoasFactory(mockAppConfig)
-      val nino: String            = "someNino"
-      val calcId: String          = "c432a56d-e811-474c-a26a-76fc3bcaefe5"
-      val taxYear: Option[String] = Some("2020-21")
+      val hateoasFactory   = new HateoasFactory(mockAppConfig)
+      val nino: String     = "someNino"
+      val calcId: String   = "c432a56d-e811-474c-a26a-76fc3bcaefe5"
+      val taxYear: TaxYear = TaxYear.fromMtd("2020-21")
       MockAppConfig.apiGatewayContext.returns("individuals/calculations").anyNumberOfTimes
     }
+
     "wrap response correctly when tax year is defined" in new Test {
-      hateoasFactory.wrapList(listCalculationsResponseModel, ListCalculationsHateoasData(nino, taxYear)) shouldBe
+      hateoasFactory.wrapList(listCalculationsResponseModel, ListCalculationsHateoasData(nino, Some(taxYear))) shouldBe
         HateoasWrapper(
           payload = ListCalculationsResponse(
             Seq(
@@ -56,14 +58,14 @@ class ListCalculationsResponseSpec extends UnitSpec with ListCalculationsFixture
                 calculationModel,
                 Seq(
                   Link(
-                    href = s"/individuals/calculations/someNino/self-assessment/${taxYear.get}/$calcId",
+                    href = s"/individuals/calculations/someNino/self-assessment/2020-21/$calcId",
                     rel = RelType.SELF,
                     method = Method.GET
                   )
                 )))),
           links = Seq(
             Link(
-              href = s"/individuals/calculations/someNino/self-assessment/${taxYear.get}",
+              href = s"/individuals/calculations/someNino/self-assessment/2020-21",
               rel = RelType.TRIGGER,
               method = Method.POST
             ),
@@ -75,6 +77,63 @@ class ListCalculationsResponseSpec extends UnitSpec with ListCalculationsFixture
           )
         )
     }
+
+    "omit trigger link when tax year param is not provided" in new Test {
+      hateoasFactory.wrapList(listCalculationsResponseModel, ListCalculationsHateoasData(nino, None)) shouldBe
+        HateoasWrapper(
+          payload = ListCalculationsResponse(
+            Seq(
+              HateoasWrapper(
+                calculationModel,
+                Seq(
+                  Link(
+                    href = s"/individuals/calculations/someNino/self-assessment/2020-21/$calcId",
+                    rel = RelType.SELF,
+                    method = Method.GET
+                  )
+                )))),
+          links = Seq(
+            Link(
+              href = "/individuals/calculations/someNino/self-assessment",
+              rel = RelType.SELF,
+              method = Method.GET
+            )
+          )
+        )
+    }
+
+    // TODO: Implement me
+//    "do ??? when calculation does not contain tax year" in new Test {
+//      val calculationWithoutTaxYear = calculationModel.copy(taxYear = None)
+//      val responseWithoutTaxYear    = ListCalculationsResponse(Seq(calculationWithoutTaxYear))
+//
+//      hateoasFactory.wrapList(responseWithoutTaxYear, ListCalculationsHateoasData(nino, Some(taxYear))) shouldBe
+//        HateoasWrapper(
+//          payload = ListCalculationsResponse(
+//            Seq(
+//              HateoasWrapper(
+//                calculationModel,
+//                Seq(
+//                  Link(
+//                    href = s"/individuals/calculations/someNino/self-assessment/2020-21/$calcId",
+//                    rel = RelType.SELF,
+//                    method = Method.GET
+//                  )
+//                )))),
+//          links = Seq(
+//            Link(
+//              href = s"/individuals/calculations/someNino/self-assessment/2020-21",
+//              rel = RelType.TRIGGER,
+//              method = Method.POST
+//            ),
+//            Link(
+//              href = "/individuals/calculations/someNino/self-assessment",
+//              rel = RelType.SELF,
+//              method = Method.GET
+//            )
+//          )
+//        )
+//    }
   }
 
 }

--- a/test/v3/models/response/retrieveCalculation/RetrieveCalculationResponseSpec.scala
+++ b/test/v3/models/response/retrieveCalculation/RetrieveCalculationResponseSpec.scala
@@ -49,7 +49,7 @@ class RetrieveCalculationResponseSpec extends UnitSpec with CalculationFixture w
     trait Test extends MockAppConfig {
       val hateoasFactory = new HateoasFactory(mockAppConfig)
       val nino           = "AA999999A"
-      val taxYear        = "2021-22"
+      val taxYear        = TaxYear.fromMtd("2021-22")
       val calculationId  = "f2fb30e5-4ab6-4a29-b3c1-c7264259ff1c"
       MockAppConfig.apiGatewayContext.returns("some-context").anyNumberOfTimes
     }
@@ -104,9 +104,9 @@ class RetrieveCalculationResponseSpec extends UnitSpec with CalculationFixture w
           )) shouldBe HateoasWrapper(
           model,
           Seq(
-            Link(s"/some-context/$nino/self-assessment/$taxYear", POST, "trigger"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId", GET, "self"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId/final-declaration", POST, "submit-final-declaration")
+            Link(s"/some-context/$nino/self-assessment/2021-22", POST, "trigger"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId", GET, "self"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId/final-declaration", POST, "submit-final-declaration")
           )
         )
       }
@@ -127,9 +127,9 @@ class RetrieveCalculationResponseSpec extends UnitSpec with CalculationFixture w
           )) shouldBe HateoasWrapper(
           model,
           Seq(
-            Link(s"/some-context/$nino/self-assessment/$taxYear", POST, "trigger"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId", GET, "self"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId/final-declaration", POST, "submit-final-declaration")
+            Link(s"/some-context/$nino/self-assessment/2021-22", POST, "trigger"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId", GET, "self"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId/final-declaration", POST, "submit-final-declaration")
           )
         )
       }
@@ -150,9 +150,9 @@ class RetrieveCalculationResponseSpec extends UnitSpec with CalculationFixture w
           )) shouldBe HateoasWrapper(
           model,
           Seq(
-            Link(s"/some-context/$nino/self-assessment/$taxYear", POST, "trigger"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId", GET, "self"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId/final-declaration", POST, "submit-final-declaration")
+            Link(s"/some-context/$nino/self-assessment/2021-22", POST, "trigger"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId", GET, "self"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId/final-declaration", POST, "submit-final-declaration")
           )
         )
       }
@@ -176,8 +176,8 @@ class RetrieveCalculationResponseSpec extends UnitSpec with CalculationFixture w
           )) shouldBe HateoasWrapper(
           model,
           Seq(
-            Link(s"/some-context/$nino/self-assessment/$taxYear", POST, "trigger"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId", GET, "self")
+            Link(s"/some-context/$nino/self-assessment/2021-22", POST, "trigger"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId", GET, "self")
           )
         )
       }
@@ -198,8 +198,8 @@ class RetrieveCalculationResponseSpec extends UnitSpec with CalculationFixture w
           )) shouldBe HateoasWrapper(
           model,
           Seq(
-            Link(s"/some-context/$nino/self-assessment/$taxYear", POST, "trigger"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId", GET, "self")
+            Link(s"/some-context/$nino/self-assessment/2021-22", POST, "trigger"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId", GET, "self")
           )
         )
       }
@@ -220,8 +220,8 @@ class RetrieveCalculationResponseSpec extends UnitSpec with CalculationFixture w
           )) shouldBe HateoasWrapper(
           model,
           Seq(
-            Link(s"/some-context/$nino/self-assessment/$taxYear", POST, "trigger"),
-            Link(s"/some-context/$nino/self-assessment/$taxYear/$calculationId", GET, "self")
+            Link(s"/some-context/$nino/self-assessment/2021-22", POST, "trigger"),
+            Link(s"/some-context/$nino/self-assessment/2021-22/$calculationId", GET, "self")
           )
         )
       }

--- a/test/v3/models/response/triggerCalculation/TriggerCalculationResponseSpec.scala
+++ b/test/v3/models/response/triggerCalculation/TriggerCalculationResponseSpec.scala
@@ -76,7 +76,7 @@ class TriggerCalculationResponseSpec extends UnitSpec {
           HateoasWrapper(
             triggerCalculationResponseModel,
             Seq(
-              Link(s"/individuals/calculations/$nino/self-assessment", GET, "list"),
+              Link(s"/individuals/calculations/$nino/self-assessment?taxYear=2020-21", GET, "list"),
               Link(s"/individuals/calculations/$nino/self-assessment/2020-21/$calculationId", GET, "self")
             )
           )

--- a/test/v3/models/response/triggerCalculation/TriggerCalculationResponseSpec.scala
+++ b/test/v3/models/response/triggerCalculation/TriggerCalculationResponseSpec.scala
@@ -20,6 +20,7 @@ import mocks.MockAppConfig
 import play.api.libs.json.{JsValue, Json}
 import support.UnitSpec
 import v3.hateoas.HateoasFactory
+import v3.models.domain.TaxYear
 import v3.models.hateoas.Method.GET
 import v3.models.hateoas.{HateoasWrapper, Link}
 
@@ -63,7 +64,7 @@ class TriggerCalculationResponseSpec extends UnitSpec {
     class Test extends MockAppConfig {
       val hateoasFactory = new HateoasFactory(mockAppConfig)
       val nino           = "someNino"
-      val taxYear        = "2020-21"
+      val taxYear        = TaxYear.fromMtd("2020-21")
       MockAppConfig.apiGatewayContext.returns("individuals/calculations").anyNumberOfTimes
     }
 
@@ -76,7 +77,7 @@ class TriggerCalculationResponseSpec extends UnitSpec {
             triggerCalculationResponseModel,
             Seq(
               Link(s"/individuals/calculations/$nino/self-assessment", GET, "list"),
-              Link(s"/individuals/calculations/$nino/self-assessment/$taxYear/$calculationId", GET, "self")
+              Link(s"/individuals/calculations/$nino/self-assessment/2020-21/$calculationId", GET, "self")
             )
           )
       }


### PR DESCRIPTION
This HATEOAS ticket differs from other TYS hateoas tickets, in that no endpoint has a _new_ taxYear param. Of the four endpoints, three have the taxYear as a path parameter (retrieve, trigger, submit) so no updates are needed as the tax year is already included in the hateoas link.

For the list endpoint, the taxYear query param was already a thing pre-TYS but was never added to the hateoas links. Fatih confirmed that it should have been added, so this ticket updates the hateoas link generation to always append the taxYear query param to the list link, modifying the hateoas responses in some non-TYS cases too.

Also there was an unimplemented scenario in the List link generation, for when the taxYear query parameter was not supplied. Fatih confirmed the trigger link should be omitted in this scenario, and that for the retrieve links in the calculations array, we should use the returned taxYear in the calculation.