### PR TITLE
Multi Error Mapping POC to isolate schema, error mapping and urls as tax year validations or changes can be different per tax year

### DIFF
--- a/app/shared/services/DownstreamResponseMappingSupport.scala
+++ b/app/shared/services/DownstreamResponseMappingSupport.scala
@@ -32,10 +32,6 @@ trait DownstreamResponseMappingSupport {
         logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No matching stub was found")
         RuleIncorrectGovTestScenarioError
 
-      case "INVALID_CORRELATION_ID" | "INVALID_CORRELATIONID" =>
-        logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - An internal server error occurred")
-        InternalError
-
       case code =>
         logger.warn(s"[${logContext.controllerName}] [${logContext.endpointName}] - No mapping found for error code $code")
         InternalError

--- a/app/v7/retrieveCalculation/RetrieveCalculationService.scala
+++ b/app/v7/retrieveCalculation/RetrieveCalculationService.scala
@@ -17,9 +17,9 @@
 package v7.retrieveCalculation
 
 import shared.controllers.RequestContext
-import shared.models.errors._
 import shared.services.{BaseService, ServiceOutcome}
 import cats.implicits._
+import v7.retrieveCalculation.downstreamErrorMapping.RetrieveDownstreamErrorMapping.errorMapFor
 import v7.retrieveCalculation.models.request.RetrieveCalculationRequestData
 import v7.retrieveCalculation.models.response.RetrieveCalculationResponse
 
@@ -33,31 +33,7 @@ class RetrieveCalculationService @Inject() (connector: RetrieveCalculationConnec
       ctx: RequestContext,
       ec: ExecutionContext): Future[ServiceOutcome[RetrieveCalculationResponse]] = {
 
-    connector.retrieveCalculation(request).map(_.leftMap(mapDownstreamErrors(downstreamErrorMap)))
+    connector.retrieveCalculation(request).map(_.leftMap(mapDownstreamErrors(errorMapFor(request.taxYear).errorMap)))
 
   }
-
-  private val downstreamErrorMap: Map[String, MtdError] = {
-    val errors: Map[String, MtdError] = Map(
-      "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
-      "INVALID_CALCULATION_ID"    -> CalculationIdFormatError,
-      "INVALID_CORRELATIONID"     -> InternalError,
-      "INVALID_CONSUMERID"        -> InternalError,
-      "NO_DATA_FOUND"             -> NotFoundError,
-      "SERVER_ERROR"              -> InternalError,
-      "SERVICE_UNAVAILABLE"       -> InternalError,
-      "UNMATCHED_STUB_ERROR"      -> RuleIncorrectGovTestScenarioError
-    )
-
-    val extraTysErrors: Map[String, MtdError] = Map(
-      "INVALID_TAX_YEAR"       -> TaxYearFormatError,
-      "INVALID_CORRELATION_ID" -> InternalError,
-      "INVALID_CONSUMER_ID"    -> InternalError,
-      "NOT_FOUND"              -> NotFoundError,
-      "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
-    )
-
-    errors ++ extraTysErrors
-  }
-
 }

--- a/app/v7/retrieveCalculation/downstreamErrorMapping/RetrieveDownstreamErrorMapping.scala
+++ b/app/v7/retrieveCalculation/downstreamErrorMapping/RetrieveDownstreamErrorMapping.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v7.retrieveCalculation.downstreamErrorMapping
+
+import shared.models.domain.TaxYear
+import shared.models.errors._
+
+import scala.math.Ordered.orderingToOrdered
+
+sealed trait RetrieveDownstreamErrorMapping {
+  def errorMap: Map[String, MtdError]
+}
+
+object RetrieveDownstreamErrorMapping {
+
+  private val commonErrorsMap: Map[String, MtdError] = Map(
+    "INVALID_TAXABLE_ENTITY_ID" -> NinoFormatError,
+    "INVALID_CALCULATION_ID"    -> CalculationIdFormatError,
+    "SERVER_ERROR"              -> InternalError,
+    "SERVICE_UNAVAILABLE"       -> InternalError
+  )
+
+  case object PreTys extends RetrieveDownstreamErrorMapping {
+    val errorMap: Map[String, MtdError] = commonErrorsMap ++ Map(
+      "INVALID_CORRELATIONID" -> InternalError,
+      "INVALID_CONSUMERID"    -> InternalError,
+      "NO_DATA_FOUND"         -> NotFoundError
+    )
+  }
+
+  // All other case objects were split in the case there is different mapping per tax year
+  case object TaxYear2023 extends RetrieveDownstreamErrorMapping {
+    val errorMap: Map[String, MtdError] = commonErrorsMap ++ Map(
+      "INVALID_TAX_YEAR"       -> TaxYearFormatError,
+      "INVALID_CORRELATION_ID" -> InternalError,
+      "INVALID_CONSUMER_ID"    -> InternalError,
+      "NOT_FOUND"              -> NotFoundError,
+      "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
+    )
+  }
+
+  case object TaxYear2024 extends RetrieveDownstreamErrorMapping {
+    val errorMap: Map[String, MtdError] = TaxYear2023.errorMap
+  }
+
+  case object TaxYear2025 extends RetrieveDownstreamErrorMapping {
+    val errorMap: Map[String, MtdError] = TaxYear2023.errorMap
+  }
+
+  def errorMapFor(taxYear: TaxYear): RetrieveDownstreamErrorMapping = taxYear match {
+    case ty if ty >= TaxYear.fromMtd("2025-26") => TaxYear2025
+    case ty if ty == TaxYear.fromMtd("2024-25") => TaxYear2024
+    case ty if ty == TaxYear.fromMtd("2023-24") => TaxYear2023
+    case _                                      => PreTys
+  }
+}

--- a/it/v7/retrieveCalculation/def2/Def2_RetrieveCalculationControllerISpec.scala
+++ b/it/v7/retrieveCalculation/def2/Def2_RetrieveCalculationControllerISpec.scala
@@ -110,42 +110,35 @@ class Def2_RetrieveCalculationControllerISpec extends IntegrationBaseSpec with D
           ("ZG903729C", "2017-18", "bad id", BAD_REQUEST, CalculationIdFormatError)
         )
         input.foreach(args => (validationErrorTest _).tupled(args))
-        "downstream returns a service error" when {
-          def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-            s"backend returns an $downstreamCode error and status $downstreamStatus" in new Test {
-              override def setupStubs(): StubMapping = {
-                AuditStub.audit()
-                AuthStub.authorised()
-                MtdIdLookupStub.ninoFound(nino)
-                DownstreamStub.onError(DownstreamStub.GET, downstreamUri, downstreamStatus, errorBody(downstreamCode))
-              }
-              val response: WSResponse = await(request.get())
-              response.status shouldBe expectedStatus
-              response.json shouldBe Json.toJson(expectedBody)
-              response.header("Content-Type") shouldBe Some("application/json")
+
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns the $downstreamCode error and status $downstreamStatus" in new Test {
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.GET, downstreamUri, downstreamStatus, errorBody(downstreamCode))
             }
+            val response: WSResponse = await(request.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
           }
-          val errors = Seq(
-            (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
-            (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
-            (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
-            (BAD_REQUEST, "INVALID_CONSUMERID", INTERNAL_SERVER_ERROR, InternalError),
-            (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
-            (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
-            (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
-            (NOT_FOUND, "UNMATCHED_STUB_ERROR", BAD_REQUEST, RuleIncorrectGovTestScenarioError)
-          )
-          val extraTysErrors = Seq(
-            (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
-            (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
-            (BAD_REQUEST, "INVALID_CONSUMER_ID", INTERNAL_SERVER_ERROR, InternalError),
-            (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
-            (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
-          )
-          (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
         }
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_CONSUMER_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "UNMATCHED_STUB_ERROR", BAD_REQUEST, RuleIncorrectGovTestScenarioError)
+        )
+        errors.foreach(args => (serviceErrorTest _).tupled(args))
       }
     }
   }
-
 }

--- a/it/v7/retrieveCalculation/def3/Def3_RetrieveCalculationControllerISpec.scala
+++ b/it/v7/retrieveCalculation/def3/Def3_RetrieveCalculationControllerISpec.scala
@@ -110,42 +110,35 @@ class Def3_RetrieveCalculationControllerISpec extends IntegrationBaseSpec with D
           ("ZG903729C", "2017-18", "bad id", BAD_REQUEST, CalculationIdFormatError)
         )
         input.foreach(args => (validationErrorTest _).tupled(args))
-        "downstream returns a service error" when {
-          def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-            s"backend returns an $downstreamCode error and status $downstreamStatus" in new Test {
-              override def setupStubs(): StubMapping = {
-                AuditStub.audit()
-                AuthStub.authorised()
-                MtdIdLookupStub.ninoFound(nino)
-                DownstreamStub.onError(DownstreamStub.GET, downstreamUri, downstreamStatus, errorBody(downstreamCode))
-              }
-              val response: WSResponse = await(request.get())
-              response.status shouldBe expectedStatus
-              response.json shouldBe Json.toJson(expectedBody)
-              response.header("Content-Type") shouldBe Some("application/json")
+
+        def serviceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns the $downstreamCode error and status $downstreamStatus" in new Test {
+            override def setupStubs(): StubMapping = {
+              AuditStub.audit()
+              AuthStub.authorised()
+              MtdIdLookupStub.ninoFound(nino)
+              DownstreamStub.onError(DownstreamStub.GET, downstreamUri, downstreamStatus, errorBody(downstreamCode))
             }
+            val response: WSResponse = await(request.get())
+            response.status shouldBe expectedStatus
+            response.json shouldBe Json.toJson(expectedBody)
+            response.header("Content-Type") shouldBe Some("application/json")
           }
-          val errors = Seq(
-            (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
-            (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
-            (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, InternalError),
-            (BAD_REQUEST, "INVALID_CONSUMERID", INTERNAL_SERVER_ERROR, InternalError),
-            (NOT_FOUND, "NO_DATA_FOUND", NOT_FOUND, NotFoundError),
-            (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
-            (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
-            (NOT_FOUND, "UNMATCHED_STUB_ERROR", BAD_REQUEST, RuleIncorrectGovTestScenarioError)
-          )
-          val extraTysErrors = Seq(
-            (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
-            (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
-            (BAD_REQUEST, "INVALID_CONSUMER_ID", INTERNAL_SERVER_ERROR, InternalError),
-            (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
-            (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError)
-          )
-          (errors ++ extraTysErrors).foreach(args => (serviceErrorTest _).tupled(args))
         }
+        val errors = Seq(
+          (BAD_REQUEST, "INVALID_TAXABLE_ENTITY_ID", BAD_REQUEST, NinoFormatError),
+          (BAD_REQUEST, "INVALID_CALCULATION_ID", BAD_REQUEST, CalculationIdFormatError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATION_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (BAD_REQUEST, "INVALID_CONSUMER_ID", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+          (INTERNAL_SERVER_ERROR, "SERVER_ERROR", INTERNAL_SERVER_ERROR, InternalError),
+          (SERVICE_UNAVAILABLE, "SERVICE_UNAVAILABLE", INTERNAL_SERVER_ERROR, InternalError),
+          (NOT_FOUND, "UNMATCHED_STUB_ERROR", BAD_REQUEST, RuleIncorrectGovTestScenarioError)
+        )
+        errors.foreach(args => (serviceErrorTest _).tupled(args))
       }
     }
   }
-
 }

--- a/test/v7/retrieveCalculation/RetrieveCalculationServiceSpec.scala
+++ b/test/v7/retrieveCalculation/RetrieveCalculationServiceSpec.scala
@@ -22,6 +22,8 @@ import shared.models.outcomes.ResponseWrapper
 import shared.services.ServiceSpec
 import uk.gov.hmrc.http.HeaderCarrier
 import v7.retrieveCalculation.def1.model.Def1_CalculationFixture
+import v7.retrieveCalculation.downstreamErrorMapping.RetrieveDownstreamErrorMapping
+import v7.retrieveCalculation.downstreamErrorMapping.RetrieveDownstreamErrorMapping._
 import v7.retrieveCalculation.models.request.{Def1_RetrieveCalculationRequestData, RetrieveCalculationRequestData}
 import v7.retrieveCalculation.models.response.RetrieveCalculationResponse
 
@@ -29,11 +31,14 @@ import scala.concurrent.Future
 
 class RetrieveCalculationServiceSpec extends ServiceSpec with Def1_CalculationFixture {
 
-  private val nino: Nino                   = Nino("ZG903729C")
-  private val taxYear: TaxYear             = TaxYear.fromMtd("2019-20")
+  private val nino: Nino = Nino("ZG903729C")
   private val calculationId: CalculationId = CalculationId("someCalcId")
 
-  val request: RetrieveCalculationRequestData = Def1_RetrieveCalculationRequestData(nino, taxYear, calculationId)
+  def request(taxYear: String): RetrieveCalculationRequestData = Def1_RetrieveCalculationRequestData(
+    nino = nino,
+    taxYear = TaxYear.fromMtd(taxYear),
+    calculationId = calculationId
+  )
   val response: RetrieveCalculationResponse   = minimalCalculationResponse
 
   trait Test extends MockRetrieveCalculationConnector {
@@ -42,51 +47,45 @@ class RetrieveCalculationServiceSpec extends ServiceSpec with Def1_CalculationFi
     val service = new RetrieveCalculationService(mockConnector)
   }
 
-  "retrieveCalculation" should {
-    "return a valid response" when {
-      "a valid request is supplied" in new Test {
-        MockRetrieveCalculationConnector
-          .retrieveCalculation(request)
-          .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
-
-        await(service.retrieveCalculation(request)) shouldBe Right(ResponseWrapper(correlationId, response))
-      }
-    }
-
-    "return error response" when {
-
-      def serviceError(downstreamErrorCode: String, error: MtdError): Unit =
-        s"a $downstreamErrorCode error is returned from the service" in new Test {
-
+  "RetrieveCalculationService" when {
+    "retrieveCalculation" should {
+      "return a valid response" when {
+        "a valid request is supplied" in new Test {
           MockRetrieveCalculationConnector
-            .retrieveCalculation(request)
-            .returns(Future.successful(Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))))
+            .retrieveCalculation(request("2025-26"))
+            .returns(Future.successful(Right(ResponseWrapper(correlationId, response))))
 
-          await(service.retrieveCalculation(request)) shouldBe Left(ErrorWrapper(correlationId, error))
+          await(service.retrieveCalculation(request("2025-26"))) shouldBe Right(ResponseWrapper(correlationId, response))
+        }
+      }
+
+      "return error response" when {
+        def serviceError(taxYear: String, downstreamErrorMapping: RetrieveDownstreamErrorMapping): Unit = {
+          val fullDownstreamErrorMap: Map[String, MtdError] = downstreamErrorMapping.errorMap ++ Map(
+            "UNMATCHED_STUB_ERROR" -> RuleIncorrectGovTestScenarioError
+          )
+          fullDownstreamErrorMap.foreach { case (downstreamErrorCode, expectedError) =>
+            s"the $downstreamErrorCode error for tax year $taxYear is returned from the service" in new Test {
+              MockRetrieveCalculationConnector
+                .retrieveCalculation(request(taxYear))
+                .returns(Future.successful(
+                  Left(ResponseWrapper(correlationId, DownstreamErrors.single(DownstreamErrorCode(downstreamErrorCode))))
+                ))
+
+              await(service.retrieveCalculation(request(taxYear))) shouldBe Left(ErrorWrapper(correlationId, expectedError))
+            }
+          }
         }
 
-      // TODO ensure errors match
-      val errors = Seq(
-        ("INVALID_TAXABLE_ENTITY_ID", NinoFormatError),
-        ("INVALID_CALCULATION_ID", CalculationIdFormatError),
-        ("INVALID_CORRELATIONID", InternalError),
-        ("INVALID_CONSUMERID", InternalError),
-        ("NO_DATA_FOUND", NotFoundError),
-        ("SERVER_ERROR", InternalError),
-        ("SERVICE_UNAVAILABLE", InternalError),
-        ("UNMATCHED_STUB_ERROR", RuleIncorrectGovTestScenarioError)
-      )
+        val input: Seq[(String, RetrieveDownstreamErrorMapping)] = Seq(
+          ("2022-23", PreTys),
+          ("2023-24", TaxYear2023),
+          ("2024-25", TaxYear2024),
+          ("2025-26", TaxYear2025)
+        )
 
-      val extraTysErrors = Seq(
-        ("INVALID_TAX_YEAR", TaxYearFormatError),
-        ("INVALID_CORRELATION_ID", InternalError),
-        ("INVALID_CONSUMER_ID", InternalError),
-        ("NOT_FOUND", NotFoundError),
-        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError)
-      )
-
-      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
+        input.foreach(args => (serviceError _).tupled(args))
+      }
     }
   }
-
 }

--- a/test/v7/retrieveCalculation/downstreamErrorMapping/RetrieveDownstreamErrorMappingSpec.scala
+++ b/test/v7/retrieveCalculation/downstreamErrorMapping/RetrieveDownstreamErrorMappingSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v7.retrieveCalculation.downstreamErrorMapping
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import shared.models.domain.{TaxYear, TaxYearPropertyCheckSupport}
+import shared.utils.UnitSpec
+import v7.retrieveCalculation.downstreamErrorMapping.RetrieveDownstreamErrorMapping._
+
+class RetrieveDownstreamErrorMappingSpec extends UnitSpec with ScalaCheckDrivenPropertyChecks with TaxYearPropertyCheckSupport {
+
+  "RetrieveDownstreamErrorMapping" should {
+    "return correct downstream error mapping for pre Tax Year Specific (TYS) tax years" in {
+      forPreTysTaxYears { taxYear =>
+        val downstreamErrorMapping: RetrieveDownstreamErrorMapping = errorMapFor(taxYear)
+
+        downstreamErrorMapping shouldBe PreTys
+        downstreamErrorMapping.errorMap.keys should contain.allOf(
+          "INVALID_TAXABLE_ENTITY_ID",
+          "INVALID_CALCULATION_ID",
+          "INVALID_CORRELATIONID",
+          "INVALID_CONSUMERID",
+          "NO_DATA_FOUND",
+          "SERVER_ERROR",
+          "SERVICE_UNAVAILABLE"
+        )
+      }
+    }
+
+    "return correct downstream error mapping for tax year 2023-24" in {
+      val downstreamErrorMapping: RetrieveDownstreamErrorMapping = errorMapFor(TaxYear.fromMtd("2023-24"))
+
+      downstreamErrorMapping shouldBe TaxYear2023
+      downstreamErrorMapping.errorMap.keys should contain.allOf(
+        "INVALID_TAXABLE_ENTITY_ID",
+        "INVALID_CALCULATION_ID",
+        "INVALID_TAX_YEAR",
+        "INVALID_CORRELATION_ID",
+        "INVALID_CONSUMER_ID",
+        "NOT_FOUND",
+        "TAX_YEAR_NOT_SUPPORTED",
+        "SERVER_ERROR",
+        "SERVICE_UNAVAILABLE"
+      )
+    }
+
+    "return correct downstream error mapping for tax year 2024-25" in {
+      val downstreamErrorMapping: RetrieveDownstreamErrorMapping = errorMapFor(TaxYear.fromMtd("2024-25"))
+
+      downstreamErrorMapping shouldBe TaxYear2024
+      downstreamErrorMapping.errorMap.keys should contain.allOf(
+        "INVALID_TAXABLE_ENTITY_ID",
+        "INVALID_CALCULATION_ID",
+        "INVALID_TAX_YEAR",
+        "INVALID_CORRELATION_ID",
+        "INVALID_CONSUMER_ID",
+        "NOT_FOUND",
+        "TAX_YEAR_NOT_SUPPORTED",
+        "SERVER_ERROR",
+        "SERVICE_UNAVAILABLE"
+      )
+    }
+
+    "return correct downstream error mapping for tax years 2025-26 onwards" in {
+      forTaxYearsFrom(TaxYear.fromMtd("2025-26")) { taxYear =>
+        val downstreamErrorMapping: RetrieveDownstreamErrorMapping = errorMapFor(taxYear)
+
+        downstreamErrorMapping shouldBe TaxYear2025
+        downstreamErrorMapping.errorMap.keys should contain.allOf(
+          "INVALID_TAXABLE_ENTITY_ID",
+          "INVALID_CALCULATION_ID",
+          "INVALID_TAX_YEAR",
+          "INVALID_CORRELATION_ID",
+          "INVALID_CONSUMER_ID",
+          "NOT_FOUND",
+          "TAX_YEAR_NOT_SUPPORTED",
+          "SERVER_ERROR",
+          "SERVICE_UNAVAILABLE"
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
Handling all tax year logic for error mapping in the RetrieveDownstreamErrorMapping. Based on multi schema approach for simplicity.