### PR TITLE
MTDSA-31026: Align HICBC downstream fields for API#1885

### DIFF
--- a/app/v7/retrieveCalculation/def3/model/response/calculation/highIncomeChildBenefitCharge/HighIncomeChildBenefitCharge.scala
+++ b/app/v7/retrieveCalculation/def3/model/response/calculation/highIncomeChildBenefitCharge/HighIncomeChildBenefitCharge.scala
@@ -16,7 +16,8 @@
 
 package v7.retrieveCalculation.def3.model.response.calculation.highIncomeChildBenefitCharge
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.*
 
 case class HighIncomeChildBenefitCharge(adjustedNetIncome: BigDecimal,
                                         amountOfChildBenefitReceived: BigDecimal,
@@ -26,5 +27,15 @@ case class HighIncomeChildBenefitCharge(adjustedNetIncome: BigDecimal,
                                         highIncomeBenefitCharge: BigDecimal)
 
 object HighIncomeChildBenefitCharge {
-  implicit val format: OFormat[HighIncomeChildBenefitCharge] = Json.format[HighIncomeChildBenefitCharge]
+
+  given Reads[HighIncomeChildBenefitCharge] = (
+    (JsPath \ "adjustedNetIncome").read[BigDecimal] and
+      (JsPath \ "amountOfChildBenefitReceived").read[BigDecimal] and
+      (JsPath \ "incomeThreshold").read[BigDecimal] and
+      (JsPath \ "childBenefitChargeTaper").read[BigDecimal] and
+      (JsPath \ "rate").read[BigDecimal] and
+      (JsPath \ "highIncomeChildBenefitCharge").read[BigDecimal]
+  )(HighIncomeChildBenefitCharge.apply)
+
+  given OWrites[HighIncomeChildBenefitCharge] = Json.writes[HighIncomeChildBenefitCharge]
 }

--- a/app/v7/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTax.scala
+++ b/app/v7/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTax.scala
@@ -16,7 +16,8 @@
 
 package v7.retrieveCalculation.def3.model.response.calculation.taxCalculation
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.*
 
 case class IncomeTax(
     totalIncomeReceivedFromAllSources: BigInt,
@@ -43,5 +44,30 @@ case class IncomeTax(
 )
 
 object IncomeTax {
-  implicit val format: Format[IncomeTax] = Json.format
+
+  given Reads[IncomeTax] = (
+    (JsPath \ "totalIncomeReceivedFromAllSources").read[BigInt] and
+      (JsPath \ "totalAllowancesAndDeductions").read[BigInt] and
+      (JsPath \ "totalTaxableIncome").read[BigInt] and
+      (JsPath \ "payPensionsProfit").readNullable[IncomeTaxItem] and
+      (JsPath \ "savingsAndGains").readNullable[IncomeTaxItem] and
+      (JsPath \ "dividends").readNullable[IncomeTaxItem] and
+      (JsPath \ "lumpSums").readNullable[IncomeTaxItem] and
+      (JsPath \ "gainsOnLifePolicies").readNullable[IncomeTaxItem] and
+      (JsPath \ "incomeTaxCharged").read[BigDecimal] and
+      (JsPath \ "totalReliefs").readNullable[BigDecimal] and
+      (JsPath \ "incomeTaxDueAfterReliefs").readNullable[BigDecimal] and
+      (JsPath \ "totalNotionalTax").readNullable[BigDecimal] and
+      (JsPath \ "marriageAllowanceRelief").readNullable[BigDecimal] and
+      (JsPath \ "incomeTaxDueAfterTaxReductions").readNullable[BigDecimal] and
+      (JsPath \ "incomeTaxDueAfterGiftAid").readNullable[BigDecimal] and
+      (JsPath \ "totalPensionSavingsTaxCharges").readNullable[BigDecimal] and
+      (JsPath \ "statePensionLumpSumCharges").readNullable[BigDecimal] and
+      (JsPath \ "payeUnderpaymentsCodedOut").readNullable[BigDecimal] and
+      (JsPath \ "totalIncomeTaxDue").readNullable[BigDecimal] and
+      (JsPath \ "giftAidTaxChargeWhereBasicRateDiffers").readNullable[BigDecimal] and
+      (JsPath \ "highIncomeChildBenefitCharge").readNullable[BigDecimal]
+  )(IncomeTax.apply)
+
+  given OWrites[IncomeTax] = Json.writes[IncomeTax]
 }

--- a/app/v8/retrieveCalculation/def3/model/response/calculation/highIncomeChildBenefitCharge/HighIncomeChildBenefitCharge.scala
+++ b/app/v8/retrieveCalculation/def3/model/response/calculation/highIncomeChildBenefitCharge/HighIncomeChildBenefitCharge.scala
@@ -16,7 +16,8 @@
 
 package v8.retrieveCalculation.def3.model.response.calculation.highIncomeChildBenefitCharge
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.*
 
 case class HighIncomeChildBenefitCharge(adjustedNetIncome: BigDecimal,
                                         amountOfChildBenefitReceived: BigDecimal,
@@ -26,5 +27,15 @@ case class HighIncomeChildBenefitCharge(adjustedNetIncome: BigDecimal,
                                         highIncomeBenefitCharge: BigDecimal)
 
 object HighIncomeChildBenefitCharge {
-  implicit val format: OFormat[HighIncomeChildBenefitCharge] = Json.format[HighIncomeChildBenefitCharge]
+
+  given Reads[HighIncomeChildBenefitCharge] = (
+    (JsPath \ "adjustedNetIncome").read[BigDecimal] and
+      (JsPath \ "amountOfChildBenefitReceived").read[BigDecimal] and
+      (JsPath \ "incomeThreshold").read[BigDecimal] and
+      (JsPath \ "childBenefitChargeTaper").read[BigDecimal] and
+      (JsPath \ "rate").read[BigDecimal] and
+      (JsPath \ "highIncomeChildBenefitCharge").read[BigDecimal]
+  )(HighIncomeChildBenefitCharge.apply)
+
+  given OWrites[HighIncomeChildBenefitCharge] = Json.writes[HighIncomeChildBenefitCharge]
 }

--- a/app/v8/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTax.scala
+++ b/app/v8/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTax.scala
@@ -16,7 +16,8 @@
 
 package v8.retrieveCalculation.def3.model.response.calculation.taxCalculation
 
-import play.api.libs.json.{Format, Json}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.*
 
 case class IncomeTax(
     totalIncomeReceivedFromAllSources: BigInt,
@@ -43,5 +44,30 @@ case class IncomeTax(
 )
 
 object IncomeTax {
-  implicit val format: Format[IncomeTax] = Json.format
+
+  given Reads[IncomeTax] = (
+    (JsPath \ "totalIncomeReceivedFromAllSources").read[BigInt] and
+      (JsPath \ "totalAllowancesAndDeductions").read[BigInt] and
+      (JsPath \ "totalTaxableIncome").read[BigInt] and
+      (JsPath \ "payPensionsProfit").readNullable[IncomeTaxItem] and
+      (JsPath \ "savingsAndGains").readNullable[IncomeTaxItem] and
+      (JsPath \ "dividends").readNullable[IncomeTaxItem] and
+      (JsPath \ "lumpSums").readNullable[IncomeTaxItem] and
+      (JsPath \ "gainsOnLifePolicies").readNullable[IncomeTaxItem] and
+      (JsPath \ "incomeTaxCharged").read[BigDecimal] and
+      (JsPath \ "totalReliefs").readNullable[BigDecimal] and
+      (JsPath \ "incomeTaxDueAfterReliefs").readNullable[BigDecimal] and
+      (JsPath \ "totalNotionalTax").readNullable[BigDecimal] and
+      (JsPath \ "marriageAllowanceRelief").readNullable[BigDecimal] and
+      (JsPath \ "incomeTaxDueAfterTaxReductions").readNullable[BigDecimal] and
+      (JsPath \ "incomeTaxDueAfterGiftAid").readNullable[BigDecimal] and
+      (JsPath \ "totalPensionSavingsTaxCharges").readNullable[BigDecimal] and
+      (JsPath \ "statePensionLumpSumCharges").readNullable[BigDecimal] and
+      (JsPath \ "payeUnderpaymentsCodedOut").readNullable[BigDecimal] and
+      (JsPath \ "totalIncomeTaxDue").readNullable[BigDecimal] and
+      (JsPath \ "giftAidTaxChargeWhereBasicRateDiffers").readNullable[BigDecimal] and
+      (JsPath \ "highIncomeChildBenefitCharge").readNullable[BigDecimal]
+  )(IncomeTax.apply)
+
+  given OWrites[IncomeTax] = Json.writes[IncomeTax]
 }

--- a/test/resources/v7/retrieveCalculation/def3/model/response/calculation/taxCalculation/taxCalculation_downstream.json
+++ b/test/resources/v7/retrieveCalculation/def3/model/response/calculation/taxCalculation/taxCalculation_downstream.json
@@ -94,7 +94,7 @@
     "statePensionLumpSumCharges": 5000.99,
     "payeUnderpaymentsCodedOut": 5000.99,
     "totalIncomeTaxDue": 5000.99,
-    "highIncomeBenefitCharge": 5000.99
+    "highIncomeChildBenefitCharge": 5000.99
   },
   "nics": {
     "class2Nics": {

--- a/test/resources/v7/retrieveCalculation/def3/model/response/calculation_downstream.json
+++ b/test/resources/v7/retrieveCalculation/def3/model/response/calculation_downstream.json
@@ -838,7 +838,7 @@
         "statePensionLumpSumCharges": 5000.99,
         "payeUnderpaymentsCodedOut": 5000.99,
         "totalIncomeTaxDue": 5000.99,
-        "highIncomeBenefitCharge": 5000.99
+        "highIncomeChildBenefitCharge": 5000.99
       },
       "nics": {
         "class2Nics": {
@@ -1053,7 +1053,7 @@
       "incomeThreshold": 60000,
       "childBenefitChargeTaper": 200,
       "rate": 10.25,
-      "highIncomeBenefitCharge": 32000.01
+      "highIncomeChildBenefitCharge": 32000.01
     }
   },
   "messages": {

--- a/test/resources/v8.retrieveCalculation/def3/model/response/calculation/taxCalculation/taxCalculation_downstream.json
+++ b/test/resources/v8.retrieveCalculation/def3/model/response/calculation/taxCalculation/taxCalculation_downstream.json
@@ -94,7 +94,7 @@
     "statePensionLumpSumCharges": 5000.99,
     "payeUnderpaymentsCodedOut": 5000.99,
     "totalIncomeTaxDue": 5000.99,
-    "highIncomeBenefitCharge": 5000.99
+    "highIncomeChildBenefitCharge": 5000.99
   },
   "nics": {
     "class2Nics": {

--- a/test/resources/v8.retrieveCalculation/def3/model/response/calculation_downstream.json
+++ b/test/resources/v8.retrieveCalculation/def3/model/response/calculation_downstream.json
@@ -838,7 +838,7 @@
         "statePensionLumpSumCharges": 5000.99,
         "payeUnderpaymentsCodedOut": 5000.99,
         "totalIncomeTaxDue": 5000.99,
-        "highIncomeBenefitCharge": 5000.99
+        "highIncomeChildBenefitCharge": 5000.99
       },
       "nics": {
         "class2Nics": {
@@ -1053,7 +1053,7 @@
       "incomeThreshold": 60000,
       "childBenefitChargeTaper": 200,
       "rate": 10.25,
-      "highIncomeBenefitCharge": 32000.01
+      "highIncomeChildBenefitCharge": 32000.01
     }
   },
   "messages": {

--- a/test/v7/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTaxSpec.scala
+++ b/test/v7/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTaxSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package v7.retrieveCalculation.def3.model.response.calculation.taxCalculation
 
-import play.api.libs.json.JsValue
+import play.api.libs.json.*
 import shared.models.utils.JsonErrorValidators
 import shared.utils.UnitSpec
 
 class IncomeTaxSpec extends UnitSpec with JsonErrorValidators with TaxCalculationFixture {
 
-  "have the correct fields optional" when {
+  "have the correct optional fields" when {
     val json = (taxCalculationDownstreamJson \ "incomeTax").as[JsValue]
 
     testAllOptionalJsonFieldsExcept[IncomeTax](json)(
@@ -30,6 +30,10 @@ class IncomeTaxSpec extends UnitSpec with JsonErrorValidators with TaxCalculatio
       "totalAllowancesAndDeductions",
       "totalTaxableIncome",
       "incomeTaxCharged")
+  }
+
+  "error when JSON is invalid" in {
+    JsObject.empty.validate[IncomeTax].isError shouldBe true
   }
 
 }

--- a/test/v8/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTaxSpec.scala
+++ b/test/v8/retrieveCalculation/def3/model/response/calculation/taxCalculation/IncomeTaxSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package v8.retrieveCalculation.def3.model.response.calculation.taxCalculation
 
-import play.api.libs.json.JsValue
+import play.api.libs.json.*
 import shared.models.utils.JsonErrorValidators
 import shared.utils.UnitSpec
 
 class IncomeTaxSpec extends UnitSpec with JsonErrorValidators with TaxCalculationFixture {
 
-  "have the correct fields optional" when {
+  "have the correct optional fields" when {
     val json = (taxCalculationDownstreamJson \ "incomeTax").as[JsValue]
 
     testAllOptionalJsonFieldsExcept[IncomeTax](json)(
@@ -30,6 +30,10 @@ class IncomeTaxSpec extends UnitSpec with JsonErrorValidators with TaxCalculatio
       "totalAllowancesAndDeductions",
       "totalTaxableIncome",
       "incomeTaxCharged")
+  }
+
+  "error when JSON is invalid" in {
+    JsObject.empty.validate[IncomeTax].isError shouldBe true
   }
 
 }


### PR DESCRIPTION
Align downstream fields for the following (v7, v8):
`calculation/highIncomeChildBenefitCharge/highIncomeBenefitCharge`  to `.../highIncomeChildBenefitCharge`
`calculation/taxCalculation/incomeTax/highIncomeBenefitCharge` to `.../highIncomeChildBenefitCharge`