### PR TITLE
MTDSA-34214 Add partner-income enum in calculation.endOfYearEstimate incomeSource[].incomeSourceType for Retrieve a Self Assessment Tax Calculation

### DIFF
--- a/app/shared/connectors/httpparsers/HttpParser.scala
+++ b/app/shared/connectors/httpparsers/HttpParser.scala
@@ -89,7 +89,7 @@ trait HttpParser extends Logging {
       OutboundError(InternalError)
     }
 
-      singleError orElse
+    singleError orElse
       multipleErrors orElse
       multipleTopLevelErrorCodes orElse
       multipleErrorCodesInResponse orElse

--- a/app/shared/models/errors/CommonMtdErrors.scala
+++ b/app/shared/models/errors/CommonMtdErrors.scala
@@ -55,6 +55,8 @@ object BadRequestError extends MtdError("INVALID_REQUEST", "Invalid request", BA
 
 object BVRError extends MtdError("BUSINESS_ERROR", "Business validation error", BAD_REQUEST)
 
+object GatewayTimeoutError extends MtdError("GATEWAY_TIMEOUT", "The request has timed out", GATEWAY_TIMEOUT)
+
 object InvalidHttpMethodError extends MtdError("INVALID_HTTP_METHOD", "Invalid HTTP method", METHOD_NOT_ALLOWED)
 
 object InvalidBodyTypeError extends MtdError("INVALID_BODY_TYPE", "Expecting text/json or application/json body", UNSUPPORTED_MEDIA_TYPE)

--- a/app/shared/utils/ErrorHandler.scala
+++ b/app/shared/utils/ErrorHandler.scala
@@ -97,11 +97,16 @@ class ErrorHandler @Inject() (
       ex
     )
 
+    val NGINX_TIMEOUT                = 499
+    val timeoutStatusCodes: Set[Int] = Set(NGINX_TIMEOUT, GATEWAY_TIMEOUT)
+
     val (errorCode, eventType) = ex match {
-      case _: NotFoundException      => (NotFoundError, "ResourceNotFound")
-      case _: AuthorisationException => (ClientOrAgentNotAuthorisedError.withStatus401, "ClientError")
-      case _: JsValidationException  => (BadRequestError, "ServerValidationError")
-      case e: HttpException          => (BadRequestError, "ServerValidationError")
+      case _: NotFoundException                                                  => (NotFoundError, "ResourceNotFound")
+      case _: AuthorisationException                                             => (ClientOrAgentNotAuthorisedError.withStatus401, "ClientError")
+      case _: JsValidationException                                              => (BadRequestError, "ServerValidationError")
+      case _: GatewayTimeoutException                                            => (GatewayTimeoutError, "ServerTimeoutError")
+      case e: HttpException                                                      => (BadRequestError, "ServerValidationError")
+      case e: UpstreamErrorResponse if timeoutStatusCodes.contains(e.statusCode) => (GatewayTimeoutError, "ServerTimeoutError")
       case e: UpstreamErrorResponse if UpstreamErrorResponse.Upstream4xxResponse.unapply(e).isDefined =>
         (BadRequestError, "ServerValidationError")
       case e: UpstreamErrorResponse if UpstreamErrorResponse.Upstream5xxResponse.unapply(e).isDefined =>

--- a/app/v8/retrieveCalculation/def4/model/response/calculation/endOfYearEstimate/IncomeSource.scala
+++ b/app/v8/retrieveCalculation/def4/model/response/calculation/endOfYearEstimate/IncomeSource.scala
@@ -39,6 +39,7 @@ object IncomeSource {
     IncomeSourceType.`state-benefits`,
     IncomeSourceType.`gains-on-life-policies`,
     IncomeSourceType.`share-schemes`,
+    IncomeSourceType.`partner-income`,
     IncomeSourceType.`foreign-property`,
     IncomeSourceType.`foreign-savings-and-gains`,
     IncomeSourceType.`other-dividends`,

--- a/resources/public/api/conf/8.0/schemas/retrieve/def4/calculation/endOfYearEstimate.json
+++ b/resources/public/api/conf/8.0/schemas/retrieve/def4/calculation/endOfYearEstimate.json
@@ -28,6 +28,7 @@
               "state-benefits",
               "gains-on-life-policies",
               "share-schemes",
+              "partner-income",
               "foreign-property",
               "foreign-savings-and-gains",
               "other-dividends",

--- a/test/shared/utils/ErrorHandlerSpec.scala
+++ b/test/shared/utils/ErrorHandlerSpec.scala
@@ -22,10 +22,10 @@ import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.mvc.{AnyContent, RequestHeader, Result}
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
-import shared.models.errors._
+import play.api.test.Helpers.*
+import shared.models.errors.*
 import uk.gov.hmrc.auth.core.InsufficientEnrolments
-import uk.gov.hmrc.http.{HeaderCarrier, JsValidationException, NotFoundException}
+import uk.gov.hmrc.http.{GatewayTimeoutException, HeaderCarrier, JsValidationException, NotFoundException, UpstreamErrorResponse}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
 import uk.gov.hmrc.play.audit.model.{DataEvent, TruncationLog}
@@ -132,6 +132,14 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
 
         contentAsJson(result).shouldBe(BadRequestError.asJson)
       }
+
+      "Upstream4xxResponse thrown" in new Test {
+        val ex: UpstreamErrorResponse = UpstreamErrorResponse("client error", TOO_MANY_REQUESTS, TOO_MANY_REQUESTS, None.orNull)
+        val result: Future[Result]    = handler.onServerError(requestHeader, ex)
+
+        status(result) shouldBe BAD_REQUEST
+        contentAsJson(result) shouldBe BadRequestError.asJson
+      }
     }
 
     "return 500 with error body" when {
@@ -140,6 +148,33 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
         status(result).shouldBe(INTERNAL_SERVER_ERROR)
 
         contentAsJson(result).shouldBe(InternalError.asJson)
+      }
+
+      "Upstream5xxResponse thrown" in new Test {
+        val ex: UpstreamErrorResponse = UpstreamErrorResponse("server error", SERVICE_UNAVAILABLE, SERVICE_UNAVAILABLE, None.orNull)
+        val result: Future[Result]    = handler.onServerError(requestHeader, ex)
+
+        status(result) shouldBe INTERNAL_SERVER_ERROR
+        contentAsJson(result) shouldBe InternalError.asJson
+      }
+    }
+
+    "return GATEWAY_TIMEOUT with error body" when {
+      "GatewayTimeoutException is thrown" in new Test {
+        val result: Future[Result] = handler.onServerError(requestHeader, new GatewayTimeoutException("test") with NoStackTrace)
+
+        status(result) shouldBe GATEWAY_TIMEOUT
+        contentAsJson(result) shouldBe GatewayTimeoutError.asJson
+      }
+
+      Seq(499, GATEWAY_TIMEOUT).foreach { statusCode =>
+        s"a $statusCode UpstreamErrorResponse is returned" in new Test {
+          val errorResponse: UpstreamErrorResponse = UpstreamErrorResponse("request timeout", statusCode, statusCode, Map.empty)
+          val result: Future[Result]               = handler.onServerError(requestHeader, errorResponse)
+
+          status(result) shouldBe GATEWAY_TIMEOUT
+          contentAsJson(result) shouldBe GatewayTimeoutError.asJson
+        }
       }
     }
   }

--- a/test/v8/retrieveCalculation/def4/model/response/calculation/endOfYearEstimate/IncomeSourceSpec.scala
+++ b/test/v8/retrieveCalculation/def4/model/response/calculation/endOfYearEstimate/IncomeSourceSpec.scala
@@ -35,6 +35,7 @@ class IncomeSourceSpec extends UnitSpec {
         ("11", `state-benefits`),
         ("12", `gains-on-life-policies`),
         ("13", `share-schemes`),
+        ("14", `partner-income`),
         ("15", `foreign-property`),
         ("16", `foreign-savings-and-gains`),
         ("17", `other-dividends`),


### PR DESCRIPTION
Noticed the handling of timeouts were not done for this so made the change. Also, noticed that [http-verbs](https://github.com/hmrc/http-verbs) returns an exception for [timeout](https://github.com/hmrc/http-verbs/blob/main/http-verbs-play-30/src/main/scala/uk/gov/hmrc/http/client/HttpClientV2Impl.scala#L310) which we don't handle in our APIs so the APIs will still be returning 400 INVALID_REQUEST. Tickets will be created to rollout this addition check in our APIs to return GatewayTimeoutError for GatewayTimeoutException from verbs. Additionally, added `partner-income` enum to EOY estimate.